### PR TITLE
Debian 8 requires virtualenv on top of python-virtualenv

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
       - python
       - python-dev
       - python-virtualenv
+      - virtualenv
       - gcc
       - dialog
       - libaugeas0


### PR DESCRIPTION
Or pip install fails. python-virtualenv does not install the virtualenv executable.

We can maybe just specify the virtualenv command to use as /bin/true ?