### PR TITLE
Ensure webroot exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,9 @@
   - name: More python depends
     pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name=letsencrypt
 
+  - name: Ensure webroot exists
+    file: path="{{ letsencrypt_webroot_path }}" state=directory recurse=yes mode="a+rw"
+
   - name: Attempt to get the certificate using the webroot authenticator
     command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
     args:


### PR DESCRIPTION
On some systems, /var/www (or whatever webroot might be set to) may not exist yet (i.e. if nginx was installed simultaneously), and letsencrypt fails in that case. It's a simple task to fix it.