### PR TITLE
Support for old (Wheezy) package name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,14 @@
   - name: Install virtualenv (Debian)
     apt: name={{ item }} state=present
     with_items:
-      - virtualenv
-    when: ansible_distribution == 'Debian'
+      - python-virtualenv
+    when: ansible_distribution == 'Debian' and ansible_lsb.codename !=  "wheezy"
+
+  - name: Install virtualenv (Debian Wheezy)
+    apt: name={{ item }} state=present
+    with_items:
+      - python-virtualenv
+    when: ansible_distribution == 'Debian' and ansible_lsb.codename ==  "wheezy"
 
   - name: Install python depends
     pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name={{ item }} state=latest


### PR DESCRIPTION
Hey,

Nice work!

I still have the occasional box running oldstable / Wheezy.  This change seems to be all that is needed to get the role running on Wheezy, at least so far (haven't finished my tests yet -- will report back if I run into any other problems).
