### PR TITLE
Allow for already installed/running web server with standalone install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The following variables are available:
 
 `letsencrypt_server` sets the auth server. Set to `https://acme-staging.api.letsencrypt.org/directory` to use the staging server (far higher rate limits, but certs are not trusted, intended for testing)
 
+`letsencrypt_authenticator` is for which authenticator to use. Defaults to `webroot`, which will start by using the `webroot` authenticator and run the `standalone` if that fails. 
+
+`letsencrypt_parallel_web_server` is the name of the web service that you'd like to stop before attempting the `standalone` authenticator and then start afterwards. eg. `nginx` or `apache2`. This allows use of the standalone letsencrypt authenticator, but in an environment where a web server is running on the required port. This could be in a scenario where a web app is being proxied on the root url, so there is no traditional web root path. Default unset. Set `letsencrypt_authenicator` to `standalone` if you want to use this variable.  
+
 The [Let's Encrypt client](https://github.com/letsencrypt/letsencrypt) will put the certificate and accessories in `/etc/letsencrypt/live/<first listed domain>/`. For more info, see the [Let's Encrypt documentation](https://letsencrypt.readthedocs.org/en/latest/using.html#where-are-my-certificates).
 
 # Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
     - "{{ ansible_fqdn }}"
   letsencrypt_webroot_path: /var/www
   letsencrypt_authenticator: webroot
+  #letsencrypt_parallel_web_service: nginx
   letsencrypt_email: "webmaster@{{ ansible_domain }}"
   letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt --agree-tos --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}--email {{ letsencrypt_email }} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
   letsencrypt_renewal_frequency:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,10 +38,22 @@
     when: letsencrypt_authenticator == "webroot"
     ignore_errors: True
 
+  - name: stop web service
+    service:
+      name: "{{ letsencrypt_parallel_web_service }}"
+      state: stopped
+    when: letsencrypt_parallel_web_service is not undefined and letsencrypt_parallel_web_service
+
   - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
     command: "{{ letsencrypt_command }} -a standalone auth"
     args:
       creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+
+  - name: start web service
+    service:
+      name: "{{ letsencrypt_parallel_web_service }}"
+      state: started
+    when: letsencrypt_parallel_web_service is not undefined and letsencrypt_parallel_web_service
 
   - name: Fix the renewal file
     ini_file: section=renewalparams option={{ item.key }} value={{ item.value }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"


### PR DESCRIPTION
I had an nginx reverse proxy to a nodejs app running on my server, so there was no web root that letsencrypt could use. The problem is that because nginx is already running, the standalone authenticator will fail because port 80 is already bound.

So this patch just allows you to specify that you want to use the standalone authenticator and lets you specify your web server so that it can stop it, run the standalone authenticator again, and then start it again.

It feels a little hacky, but it solved my use case....