### PR TITLE
Use "become:yes" on every task

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ The following variables are available:
 
 `letsencrypt_email` needs to be set to your email address. Let's Encrypt wants it. Defaults to `webmaster@{{ ansible_fqdn }}`.
 
-`letsencrypt_rsa_key_size` allows to specify a size for the generated key.
-
 `letsencrypt_cert_domains` is a list of domains you wish to get a certificate for. It defaults to a single item with the value of `{{ ansible_fqdn }}`.
 
 `letsencrypt_install_directory` should probably be left alone, but if you set it, it will change where the letsencrypt program is installed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
   - apt: update_cache=yes cache_valid_time=3600
+    become: yes
 
   - name: Install depends
     apt: name={{ item }} state=present
+    become: yes
     with_items:
       - python
       - python-dev
@@ -18,30 +20,36 @@
 
   - name: Install virtualenv (Debian)
     apt: name={{ item }} state=present
+    become: yes
     with_items:
       - virtualenv
     when: ansible_distribution == 'Debian' and ansible_lsb.codename !=  "wheezy"
 
   - name: Install virtualenv (Debian Wheezy)
     apt: name={{ item }} state=present
+    become: yes
     with_items:
       - python-virtualenv
     when: ansible_distribution == 'Debian' and ansible_lsb.codename ==  "wheezy"
 
   - name: Install python depends
     pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name={{ item }} state=latest
+    become: yes
     with_items:
       - setuptools
       - pip
 
   - name: More python depends
     pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name=letsencrypt state=latest
+    become: yes
 
   - name: Ensure webroot exists
     file: path="{{ letsencrypt_webroot_path }}" state=directory
+    become: yes
 
   - name: Attempt to get the certificate using the webroot authenticator
     command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
+    become: yes
     args:
       creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
     when: letsencrypt_authenticator == "webroot"
@@ -49,11 +57,13 @@
 
   - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
     command: "{{ letsencrypt_command }} -a standalone auth"
+    become: yes
     args:
       creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
 
   - name: Fix the renewal file
     ini_file: section=renewalparams option={{ item.key }} value={{ item.value }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    become: yes
     with_dict:
       os_packages_only: False
       verb: certonly
@@ -64,7 +74,9 @@
 
   - name: Fix the webroot map in the renewal file
     ini_file: section="[webroot_map]" option={{ item }} value={{ letsencrypt_webroot_path }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    become: yes
     with_items: "{{ letsencrypt_cert_domains }}"
 
   - name: Install renewal cron
+    become: yes
     cron: name="Let's Encrypt Renewal" day="{{ letsencrypt_renewal_frequency.day }}" hour="{{ letsencrypt_renewal_frequency.hour }}" minute="{{ letsencrypt_renewal_frequency.minute }}" job="{{ letsencrypt_venv }}/bin/letsencrypt renew {{ letsencrypt_renewal_command_args }} > /dev/null"


### PR DESCRIPTION
Since ansible 1.9, "become: yes" is the recommended privilege escalation method. It offers more flexibility to the role user and allow a role to mix root and non-root commands explicitly

http://docs.ansible.com/ansible/become.html