### PR TITLE
use certbot instead of letsencrypt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     tags: install
 
   - name: More python depends
-    pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name=letsencrypt state=latest
+    pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name="certbot" state=latest
     become: yes
     tags: install
 


### PR DESCRIPTION
Eff changed the name of the letsencrypt client to certbot, newer versions are available under the new name.