### PR TITLE
Update letsencrypt command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
   letsencrypt_webroot_path: /var/www
   letsencrypt_authenticator: webroot
   letsencrypt_email: "webmaster@{{ ansible_domain }}"
-  letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}--email {{ letsencrypt_email }} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
+  letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text --email {{ letsencrypt_email }} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
   letsencrypt_renewal_frequency:
     day: "*"
     hour: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,18 +44,20 @@
     become: yes
 
   - name: Attempt to get the certificate using the webroot authenticator
-    command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
+    command: "{{ letsencrypt_command }} -d {{ item }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
     become: yes
     args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+      creates: "/etc/letsencrypt/live/{{ item }}"
+    with_items: letsencrypt_cert_domains
     when: letsencrypt_authenticator == "webroot"
     ignore_errors: True
 
   - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
-    command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
+    command: "{{ letsencrypt_command }} -d {{ item }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
     become: yes
     args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+      creates: "/etc/letsencrypt/live/{{ item }}"
+    with_items: letsencrypt_cert_domains
 
   - name: Fix the renewal file
     ini_file: section=renewalparams option={{ item.key }} value={{ item.value }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,6 +7,7 @@
     letsencrypt_email: admin@example.com
     letsencrypt_cert_domains:
       - www.example.com
+      - example.com
     letsencrypt_server: https://acme-staging.api.letsencrypt.org/directory
 
   roles:


### PR DESCRIPTION
Fix #30
- remove domains from main `letsencrypt_command`
- one command per domain: better granularity and control over which
  certs exists or not to be generated
