### PR TITLE
add support for specifying explicit standalone authentication arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following variables are available:
 
 `letsencrypt_renewal_command_args` add arguments to the `letsencrypt renewal` command that gets run using cron.  For example, use the renewal hooks to restart a web server.
 
+`letsencrypt_standalone_command_args` adds arguments to the standalone authentication method. This is mostly useful for specifying supported challenges, such as `--standalone-supported-challenges tls-sni-01` to limit the authentication to port 443 if something is already running on 80 or vice versa.
+
 The [Let's Encrypt client](https://github.com/letsencrypt/letsencrypt) will put the certificate and accessories in `/etc/letsencrypt/live/<first listed domain>/`. For more info, see the [Let's Encrypt documentation](https://letsencrypt.readthedocs.org/en/latest/using.html#where-are-my-certificates).
 
 # Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@
     hour: 0
     minute: 0
   letsencrypt_renewal_command_args: ''
+  letsencrypt_standalone_command_args: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,7 +62,7 @@
     ignore_errors: True
 
   - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
-    command: "{{ letsencrypt_command }} -a standalone auth"
+    command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
     become: yes
     args:
       creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"


### PR DESCRIPTION
Hi,
I used the ansible-letsencrypt role (thanks) to convert an HTTP only website to HTTPS. During this, I had to use the standalone authentication method and nginx was already listening on 80, so I needed to tell certbot to only use 443 (otherwise it tried both and failed). I did this by adding an extra variable for arguments which are passed directly to the standalone authentication command.
I believe others may find this patch useful as well.

Best regards
Beda