### PR TITLE
Use letsencrypt quiet flag for renewal

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,4 +85,4 @@
 
   - name: Install renewal cron
     become: yes
-    cron: name="Let's Encrypt Renewal" day="{{ letsencrypt_renewal_frequency.day }}" hour="{{ letsencrypt_renewal_frequency.hour }}" minute="{{ letsencrypt_renewal_frequency.minute }}" job="{{ letsencrypt_venv }}/bin/letsencrypt renew {{ letsencrypt_renewal_command_args }} > /dev/null"
+    cron: name="Let's Encrypt Renewal" day="{{ letsencrypt_renewal_frequency.day }}" hour="{{ letsencrypt_renewal_frequency.hour }}" minute="{{ letsencrypt_renewal_frequency.minute }}" job="{{ letsencrypt_venv }}/bin/letsencrypt renew --quiet {{ letsencrypt_renewal_command_args }}"


### PR DESCRIPTION
The output was going to stderr, which wasn't being redirected. This change utilizes the built in quiet feature for renewal.