### PR TITLE
Added symlink option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The following variables are available:
 
 `letsencrypt_server` sets the alternative auth server if needed. For example, during tests it's set to `https://acme-staging.api.letsencrypt.org/directory` to use the staging server (far higher rate limits, but certs are not trusted). It is not set by default.
 
+`ssl_certificate` and `ssl_certificate_key` symlinks the certificates to provided path. Both must be set.
+
 The [Let's Encrypt client](https://github.com/letsencrypt/letsencrypt) will put the certificate and accessories in `/etc/letsencrypt/live/<first listed domain>/`. For more info, see the [Let's Encrypt documentation](https://letsencrypt.readthedocs.org/en/latest/using.html#where-are-my-certificates).
 
 # Example Playbook

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,3 +107,25 @@
       hour: "{{ letsencrypt_renewal_frequency.hour }}"
       minute: "{{ letsencrypt_renewal_frequency.minute }}"
       job: "{{ letsencrypt_venv }}/bin/letsencrypt renew --quiet {{ letsencrypt_renewal_command_args }}"
+
+  - name: Create directory for to `ssl_certificate` and `ssl_certificate_key`
+    file:
+      path: '{{ item }}'
+      state: directory
+      recurse: yes
+    when: ssl_certificate and ssl_certificate_key
+    with_items:
+      - "{{ ssl_certificate|dirname }}"
+      - "{{ ssl_certificate_key|dirname }}"
+
+  - name: Symlink certificates to `ssl_certificate` and `ssl_certificate_key`
+    file:
+      src: '{{ item.src }}'
+      dest: '{{ item.dest }}'
+      state: link
+    when: ssl_certificate and ssl_certificate_key
+    with_items:
+      - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/fullchain.pem
+        dest: "{{ssl_certificate}}"
+      - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/privkey.pem
+        dest: "{{ssl_certificate_key}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,7 +108,7 @@
       minute: "{{ letsencrypt_renewal_frequency.minute }}"
       job: "{{ letsencrypt_venv }}/bin/letsencrypt renew --quiet {{ letsencrypt_renewal_command_args }}"
 
-  - name: Create directory for to `ssl_certificate` and `ssl_certificate_key`
+  - name: Create directory for `ssl_certificate` and `ssl_certificate_key`
     file:
       path: '{{ item }}'
       state: directory


### PR DESCRIPTION
Optionally, symlink the certificates to a specified dir. Something I use in my deployments to enable pluggable self signed or letsencrypt certificates.