### PR TITLE
Allow registration without email

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following variables are available:
 
 `letsencrypt_webroot_path` is the root path that gets served by your web server. Defaults to `/var/www`.
 
-`letsencrypt_email` needs to be set to your email address. Let's Encrypt wants it. Defaults to `webmaster@{{ ansible_fqdn }}`.
+`letsencrypt_email` needs to be set to your email address. Let's Encrypt wants it. Defaults to `webmaster@{{ ansible_fqdn }}`. If you _really_ want to register without providing an email address, define the variabe `letsencrypt_no_email`.
 
 `letsencrypt_rsa_key_size` allows to specify a size for the generated key.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
   letsencrypt_webroot_path: /var/www
   letsencrypt_authenticator: webroot
   letsencrypt_email: "webmaster@{{ ansible_domain }}"
-  letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}--email {{ letsencrypt_email }} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
+  letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
   letsencrypt_renewal_frequency:
     day: "*"
     hour: 0


### PR DESCRIPTION
It is possible to register with letsencrypt without providing email address. This PR exposes this function.