### PR TITLE
Multiple certificates generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ First, read Let's Encrypt's TOS and EULA. Only proceed if you agree to them.
 
 The following variables are available:
 
-`letsencrypt_webroot_path` is the root path that gets served by your web server. Defaults to `/var/www`.
+`letsencrypt_certs` array of dicts with keys `domains` (array), `webroot` (string), `ssl_certificate` (string), `ssl_certificate_key` (string), one item matches one certificate.
 
 `letsencrypt_email` needs to be set to your email address. Let's Encrypt wants it. Defaults to `webmaster@{{ ansible_fqdn }}`. If you _really_ want to register without providing an email address, define the variabe `letsencrypt_no_email`.
 
 `letsencrypt_rsa_key_size` allows to specify a size for the generated key.
-
-`letsencrypt_cert_domains` is a list of domains you wish to get a certificate for. It defaults to a single item with the value of `{{ ansible_fqdn }}`.
 
 `letsencrypt_install_directory` should probably be left alone, but if you set it, it will change where the letsencrypt program is installed.
 
@@ -36,6 +34,12 @@ The following variables are available:
 `letsencrypt_standalone_command_args` adds arguments to the standalone authentication method. This is mostly useful for specifying supported challenges, such as `--standalone-supported-challenges tls-sni-01` to limit the authentication to port 443 if something is already running on 80 or vice versa.
 
 `letsencrypt_server` sets the alternative auth server if needed. For example, during tests it's set to `https://acme-staging.api.letsencrypt.org/directory` to use the staging server (far higher rate limits, but certs are not trusted). It is not set by default.
+
+Legacy variables for generate single certificate:
+
+`letsencrypt_webroot_path` is the root path that gets served by your web server. Defaults to `/var/www`.
+
+`letsencrypt_cert_domains` is a list of domains you wish to get a certificate for. It defaults to a single item with the value of `{{ ansible_fqdn }}`.
 
 `ssl_certificate` and `ssl_certificate_key` symlinks the certificates to provided path if both are set.
 
@@ -48,10 +52,17 @@ The [Let's Encrypt client](https://github.com/letsencrypt/letsencrypt) will put 
    user: root
    roles:
      - role: letsencrypt
-       letsencrypt_webroot_path: /var/www/html
+       letsencrypt_certs:
+         - webroot: /var/www/html
+           domains:
+             - www.example.net
+             - example.net
+           ssl_certificate: /path/to/symlink/fullchain.pem
+           ssl_certificate_key: /path/to/key.pem
+         - webroot: /var/www/example
+           domains:
+             - www.example2.net
+             - example2.net
        letsencrypt_email: user@example.net
-       letsencrypt_cert_domains:
-        - www.example.net
-        - example.net
        letsencrypt_renewal_command_args: '--renew-hook "systemctl restart nginx"'
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ First, read Let's Encrypt's TOS and EULA. Only proceed if you agree to them.
 
 The following variables are available:
 
+`letsencrypt_webroot_path` is the default root path that gets served by your web server. Defaults to `/var/www`.
+
 `letsencrypt_certs` array of dicts with keys `domains` (array), `webroot` (string), `ssl_certificate` (string), `ssl_certificate_key` (string), one item matches one certificate.
 
 `letsencrypt_email` needs to be set to your email address. Let's Encrypt wants it. Defaults to `webmaster@{{ ansible_fqdn }}`. If you _really_ want to register without providing an email address, define the variabe `letsencrypt_no_email`.
@@ -37,8 +39,6 @@ The following variables are available:
 
 Legacy variables for generate single certificate:
 
-`letsencrypt_webroot_path` is the root path that gets served by your web server. Defaults to `/var/www`.
-
 `letsencrypt_cert_domains` is a list of domains you wish to get a certificate for. It defaults to a single item with the value of `{{ ansible_fqdn }}`.
 
 `ssl_certificate` and `ssl_certificate_key` symlinks the certificates to provided path if both are set.
@@ -53,8 +53,7 @@ The [Let's Encrypt client](https://github.com/letsencrypt/letsencrypt) will put 
    roles:
      - role: letsencrypt
        letsencrypt_certs:
-         - webroot: /var/www/html
-           domains:
+         - domains:
              - www.example.net
              - example.net
            ssl_certificate: /path/to/symlink/fullchain.pem

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,14 @@
 ---
   letsencrypt_src_directory: /usr/local/share/letsencrypt
   letsencrypt_venv: "{{ letsencrypt_src_directory }}/env"
-  letsencrypt_cert_domains:
-    - "{{ ansible_fqdn }}"
-  letsencrypt_webroot_path: /var/www
+  letsencrypt_cert_domains: # legacy
+  letsencrypt_webroot_path: # legacy
+  letsencrypt_certs:
+    - webroot: /var/www
+      domains:
+        - "{{ ansible_fqdn }}"
+      ssl_certificate:
+      ssl_certificate_key:
   letsencrypt_authenticator: webroot
   letsencrypt_email: "webmaster@{{ ansible_domain }}"
   letsencrypt_path: "{{ letsencrypt_venv }}/bin/letsencrypt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
   letsencrypt_src_directory: /usr/local/share/letsencrypt
   letsencrypt_venv: "{{ letsencrypt_src_directory }}/env"
   letsencrypt_cert_domains: # legacy
-  letsencrypt_webroot_path: # legacy
+  letsencrypt_webroot_path: /var/www
   letsencrypt_certs:
     - webroot: /var/www
       domains:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@
   letsencrypt_authenticator: webroot
   letsencrypt_email: "webmaster@{{ ansible_domain }}"
   letsencrypt_path: "{{ letsencrypt_venv }}/bin/letsencrypt"
-  letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
   letsencrypt_renewal_frequency:
     day: "*"
     hour: 0

--- a/tasks/cert.yml
+++ b/tasks/cert.yml
@@ -1,0 +1,76 @@
+---
+- name: Ensure webroot exists
+  file:
+    path: "{{ letsencrypt_webroot_path }}"
+    state: directory
+    follow: yes
+  become: yes
+
+- name: Attempt to get the certificate using the webroot authenticator
+  command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
+  become: yes
+  args:
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+  when: letsencrypt_authenticator == "webroot"
+  ignore_errors: True
+
+- name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
+  command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
+  become: yes
+  args:
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+
+- name: Fix the renewal file
+  ini_file:
+    section: renewalparams
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+  become: yes
+  with_dict:
+    os_packages_only: False
+    verb: certonly
+    noninteractive_mode: False
+    uir: False
+    hsts: False
+    authenticator: '{{ letsencrypt_authenticator }}'
+
+- name: Fix the webroot map in the renewal file
+  ini_file:
+    section: "[webroot_map]"
+    option: "{{ item }}"
+    value: "{{ letsencrypt_webroot_path }}"
+    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+  become: yes
+  with_items: "{{ letsencrypt_cert_domains }}"
+
+- name: Install renewal cron
+  become: yes
+  cron:
+    name: "Let's Encrypt Renewal"
+    day: "{{ letsencrypt_renewal_frequency.day }}"
+    hour: "{{ letsencrypt_renewal_frequency.hour }}"
+    minute: "{{ letsencrypt_renewal_frequency.minute }}"
+    job: "{{letsencrypt_path}} renew --quiet {{ letsencrypt_renewal_command_args }}"
+
+- name: Create directory for `ssl_certificate` and `ssl_certificate_key`
+  file:
+    path: '{{ item }}'
+    state: directory
+    recurse: yes
+  when: ssl_certificate is defined and ssl_certificate_key is defined
+  with_items:
+    - "{{ ssl_certificate|dirname }}"
+    - "{{ ssl_certificate_key|dirname }}"
+
+- name: Symlink certificates to `ssl_certificate` and `ssl_certificate_key`
+  file:
+    src: '{{ item.src }}'
+    dest: '{{ item.dest }}'
+    state: link
+  when: ssl_certificate is defined and ssl_certificate_key is defined
+  with_items:
+    - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/fullchain.pem
+      dest: "{{ssl_certificate}}"
+    - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/privkey.pem
+      dest: "{{ssl_certificate_key}}"

--- a/tasks/cert.yml
+++ b/tasks/cert.yml
@@ -1,16 +1,16 @@
 ---
-- name: Define letsencrypt_command
+- name: "{{ letsencrypt_cert.domains[0] }} : Define letsencrypt_command"
   set_fact:
     letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert.domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
 
-- name: Ensure webroot exists
+- name: "{{ letsencrypt_cert.domains[0] }} : Ensure webroot exists"
   file:
     path: "{{ letsencrypt_cert.webroot }}"
     state: directory
     follow: yes
   become: yes
 
-- name: Attempt to get the certificate using the webroot authenticator
+- name: "{{ letsencrypt_cert.domains[0] }} : Attempt to get the certificate using the webroot authenticator"
   command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_cert.webroot }} certonly"
   become: yes
   args:
@@ -18,13 +18,13 @@
   when: letsencrypt_authenticator == "webroot"
   ignore_errors: True
 
-- name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
+- name: "{{ letsencrypt_cert.domains[0] }} : Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)"
   command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
   become: yes
   args:
     creates: "/etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}"
 
-- name: Fix the renewal file
+- name: "{{ letsencrypt_cert.domains[0] }} : Fix the renewal file"
   ini_file:
     section: renewalparams
     option: "{{ item.key }}"
@@ -39,7 +39,7 @@
     hsts: False
     authenticator: '{{ letsencrypt_authenticator }}'
 
-- name: Fix the webroot map in the renewal file
+- name: "{{ letsencrypt_cert.domains[0] }} : Fix the webroot map in the renewal file"
   ini_file:
     section: "[webroot_map]"
     option: "{{ item }}"
@@ -48,7 +48,7 @@
   become: yes
   with_items: "{{ letsencrypt_cert.domains }}"
 
-- name: Install renewal cron
+- name: "{{ letsencrypt_cert.domains[0] }} : Install renewal cron"
   become: yes
   cron:
     name: "Let's Encrypt Renewal"
@@ -57,7 +57,7 @@
     minute: "{{ letsencrypt_renewal_frequency.minute }}"
     job: "{{letsencrypt_path}} renew --quiet {{ letsencrypt_renewal_command_args }}"
 
-- name: Create directory for `ssl_certificate` and `ssl_certificate_key`
+- name: "{{ letsencrypt_cert.domains[0] }} : Create directory for `ssl_certificate` and `ssl_certificate_key`"
   file:
     path: '{{ item }}'
     state: directory
@@ -67,7 +67,7 @@
     - "{{ letsencrypt_cert.ssl_certificate|dirname }}"
     - "{{ letsencrypt_cert.ssl_certificate_key|dirname }}"
 
-- name: Symlink certificates to `ssl_certificate` and `ssl_certificate_key`
+- name: "{{ letsencrypt_cert.domains[0] }} : Symlink certificates to `ssl_certificate` and `ssl_certificate_key`"
   file:
     src: '{{ item.src }}'
     dest: '{{ item.dest }}'

--- a/tasks/cert.yml
+++ b/tasks/cert.yml
@@ -1,4 +1,8 @@
 ---
+- name: Define letsencrypt_command
+  set_fact:
+    letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
+
 - name: Ensure webroot exists
   file:
     path: "{{ letsencrypt_webroot_path }}"

--- a/tasks/cert.yml
+++ b/tasks/cert.yml
@@ -1,20 +1,20 @@
 ---
 - name: Define letsencrypt_command
   set_fact:
-    letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
+    letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert.domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
 
 - name: Ensure webroot exists
   file:
-    path: "{{ letsencrypt_webroot_path }}"
+    path: "{{ letsencrypt_cert.webroot }}"
     state: directory
     follow: yes
   become: yes
 
 - name: Attempt to get the certificate using the webroot authenticator
-  command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
+  command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_cert.webroot }} certonly"
   become: yes
   args:
-    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}"
   when: letsencrypt_authenticator == "webroot"
   ignore_errors: True
 
@@ -22,14 +22,14 @@
   command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
   become: yes
   args:
-    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}"
 
 - name: Fix the renewal file
   ini_file:
     section: renewalparams
     option: "{{ item.key }}"
     value: "{{ item.value }}"
-    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert.domains[0] }}.conf"
   become: yes
   with_dict:
     os_packages_only: False
@@ -43,10 +43,10 @@
   ini_file:
     section: "[webroot_map]"
     option: "{{ item }}"
-    value: "{{ letsencrypt_webroot_path }}"
-    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    value: "{{ letsencrypt_cert.webroot }}"
+    dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert.domains[0] }}.conf"
   become: yes
-  with_items: "{{ letsencrypt_cert_domains }}"
+  with_items: "{{ letsencrypt_cert.domains }}"
 
 - name: Install renewal cron
   become: yes
@@ -62,19 +62,19 @@
     path: '{{ item }}'
     state: directory
     recurse: yes
-  when: ssl_certificate is defined and ssl_certificate_key is defined
+  when: letsencrypt_cert.ssl_certificate is defined and letsencrypt_cert.ssl_certificate_key is defined and letsencrypt_cert.ssl_certificate and letsencrypt_cert.ssl_certificate_key
   with_items:
-    - "{{ ssl_certificate|dirname }}"
-    - "{{ ssl_certificate_key|dirname }}"
+    - "{{ letsencrypt_cert.ssl_certificate|dirname }}"
+    - "{{ letsencrypt_cert.ssl_certificate_key|dirname }}"
 
 - name: Symlink certificates to `ssl_certificate` and `ssl_certificate_key`
   file:
     src: '{{ item.src }}'
     dest: '{{ item.dest }}'
     state: link
-  when: ssl_certificate is defined and ssl_certificate_key is defined
+  when: letsencrypt_cert.ssl_certificate is defined and letsencrypt_cert.ssl_certificate_key is defined and letsencrypt_cert.ssl_certificate and letsencrypt_cert.ssl_certificate_key
   with_items:
-    - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/fullchain.pem
-      dest: "{{ssl_certificate}}"
-    - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/privkey.pem
-      dest: "{{ssl_certificate_key}}"
+    - src: /etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}/fullchain.pem
+      dest: "{{letsencrypt_cert.ssl_certificate}}"
+    - src: /etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}/privkey.pem
+      dest: "{{letsencrypt_cert.ssl_certificate_key}}"

--- a/tasks/cert.yml
+++ b/tasks/cert.yml
@@ -3,15 +3,19 @@
   set_fact:
     letsencrypt_command: "{{ letsencrypt_path }} -n --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert.domains %}-d {{ domain }} {% endfor %}{% if letsencrypt_no_email is defined %}--register-unsafely-without-email{% else %}--email {{ letsencrypt_email }}{% endif %} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
 
-- name: "{{ letsencrypt_cert.domains[0] }} : Ensure webroot exists"
+- name: "{{ letsencrypt_cert.domains[0] }} : Define webroot"
+  set_fact:
+    webroot: "{% if letsencrypt_cert.webroot is defined %}{{ letsencrypt_cert.webroot }}{% else %}{{ letsencrypt_webroot_path }}{% endif %}"
+
+- name: "{{ letsencrypt_cert.domains[0] }} : Ensure webroot {{ webroot }} exists"
   file:
-    path: "{{ letsencrypt_cert.webroot }}"
+    path: "{{ webroot }}"
     state: directory
     follow: yes
   become: yes
 
 - name: "{{ letsencrypt_cert.domains[0] }} : Attempt to get the certificate using the webroot authenticator"
-  command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_cert.webroot }} certonly"
+  command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ webroot }} certonly"
   become: yes
   args:
     creates: "/etc/letsencrypt/live/{{ letsencrypt_cert.domains[0] }}"
@@ -43,7 +47,7 @@
   ini_file:
     section: "[webroot_map]"
     option: "{{ item }}"
-    value: "{{ letsencrypt_cert.webroot }}"
+    value: "{{ webroot }}"
     dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert.domains[0] }}.conf"
   become: yes
   with_items: "{{ letsencrypt_cert.domains }}"

--- a/tasks/debian-jessie.yml
+++ b/tasks/debian-jessie.yml
@@ -26,3 +26,4 @@
 - name: change the path to letsencrypt
   set_fact:
     letsencrypt_path: "/usr/bin/letsencrypt"
+  tags: configure

--- a/tasks/debian-stretch.yml
+++ b/tasks/debian-stretch.yml
@@ -12,3 +12,4 @@
 - name: change the path to letsencrypt
   set_fact:
     letsencrypt_path: "/usr/bin/letsencrypt"
+  tags: configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,21 @@
     when: ansible_distribution != "Debian"
     tags: install
 
-  - name: generate certificate
+  - name: generate certificate (single)
     include: cert.yml
+    vars:
+      letsencrypt_cert:
+        domains: "{{ letsencrypt_cert_domains }}"
+        webroot: "{{ letsencrypt_webroot_path }}"
+        ssl_certificate: "{{ ssl_certificate | default('') }}"
+        ssl_certificate_key: "{{ ssl_certificate_key | default('') }}"
+    when: letsencrypt_cert_domains and letsencrypt_webroot_path
+    tags: configure
+
+  - name: generate certificate (multiple)
+    include: cert.yml
+    with_items: "{{ letsencrypt_certs }}"
+    loop_control:
+      loop_var: letsencrypt_cert
+    when: letsencrypt_certs
     tags: configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,87 +16,18 @@
   - name: install certbot (Debian jessie)
     include: debian-jessie.yml
     when: ansible_distribution == "Debian" and ansible_distribution_release == "jessie"
+    tags: install
 
   - name: install certbot (Debian stretch)
     include: debian-stretch.yml
     when: ansible_distribution == "Debian" and ansible_distribution_release == "stretch"
+    tags: install
 
   - name: install certbot (using pip)
     include: notdebian.yml
     when: ansible_distribution != "Debian"
+    tags: install
 
-  - name: Ensure webroot exists
-    file:
-      path: "{{ letsencrypt_webroot_path }}"
-      state: directory
-      follow: yes
-    become: yes
-
-  - name: Attempt to get the certificate using the webroot authenticator
-    command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
-    become: yes
-    args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
-    when: letsencrypt_authenticator == "webroot"
-    ignore_errors: True
-
-  - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
-    command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
-    become: yes
-    args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
-
-  - name: Fix the renewal file
-    ini_file:
-      section: renewalparams
-      option: "{{ item.key }}"
-      value: "{{ item.value }}"
-      dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
-    become: yes
-    with_dict:
-      os_packages_only: False
-      verb: certonly
-      noninteractive_mode: False
-      uir: False
-      hsts: False
-      authenticator: '{{ letsencrypt_authenticator }}'
-
-  - name: Fix the webroot map in the renewal file
-    ini_file:
-      section: "[webroot_map]"
-      option: "{{ item }}"
-      value: "{{ letsencrypt_webroot_path }}"
-      dest: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
-    become: yes
-    with_items: "{{ letsencrypt_cert_domains }}"
-
-  - name: Install renewal cron
-    become: yes
-    cron:
-      name: "Let's Encrypt Renewal"
-      day: "{{ letsencrypt_renewal_frequency.day }}"
-      hour: "{{ letsencrypt_renewal_frequency.hour }}"
-      minute: "{{ letsencrypt_renewal_frequency.minute }}"
-      job: "{{letsencrypt_path}} renew --quiet {{ letsencrypt_renewal_command_args }}"
-
-  - name: Create directory for `ssl_certificate` and `ssl_certificate_key`
-    file:
-      path: '{{ item }}'
-      state: directory
-      recurse: yes
-    when: ssl_certificate is defined and ssl_certificate_key is defined
-    with_items:
-      - "{{ ssl_certificate|dirname }}"
-      - "{{ ssl_certificate_key|dirname }}"
-
-  - name: Symlink certificates to `ssl_certificate` and `ssl_certificate_key`
-    file:
-      src: '{{ item.src }}'
-      dest: '{{ item.dest }}'
-      state: link
-    when: ssl_certificate is defined and ssl_certificate_key is defined
-    with_items:
-      - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/fullchain.pem
-        dest: "{{ssl_certificate}}"
-      - src: /etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}/privkey.pem
-        dest: "{{ssl_certificate_key}}"
+  - name: generate certificate
+    include: cert.yml
+    tags: configure

--- a/tasks/notdebian.yml
+++ b/tasks/notdebian.yml
@@ -7,13 +7,11 @@
   package: name={{ item }} state=present
   become: yes
   with_items: "{{ letsencrypt_depends | default([]) }}"
-  tags: install
 
 - name: Install virtualenv
   package: name={{ item }} state=present
   become: yes
   with_items: "{{ virtualenv_package_name | default([]) }}"
-  tags: install
 
 - name: Install python depends
   pip:
@@ -26,13 +24,11 @@
   with_items:
     - setuptools
     - pip
-  tags: install
 
 - name: Install pycparser
   # https://community.letsencrypt.org/t/certbot-auto-fails-while-setting-up-virtual-environment-complains-about-package-hashes/20529/22
   pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name=pycparser version=2.13 state=present virtualenv_python=python2
   become: yes
-  tags: install
   when: ansible_os_family == "RedHat"
 
 - name: More python depends
@@ -42,4 +38,3 @@
     name: letsencrypt
     state: latest
   become: yes
-  tags: install

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,8 +5,10 @@
 
   vars:
     letsencrypt_email: admin@example.com
-    letsencrypt_cert_domains:
-      - www.example.com
+    letsencrypt_certs:
+      webroot: /var/www
+      domains:
+        - www.example.com
     letsencrypt_server: https://acme-staging.api.letsencrypt.org/directory
 
   roles:


### PR DESCRIPTION
Features:
- Introduced variable `letsencrypt_certs`.
- `letsencrypt_webroot_path` used as default webroot path.
- Integrated symlink creation feature from #56.
- `letsencrypt_cert_domains` not used anymore, but old-way variables works for backward compatibility.
- Added domain name to task names
- Added tags to all tasks, `install` and `configure`
- Possible fixed bug introduced in #59: `letsencrypt_path` was defined after `letsencrypt_command` define, so `letsencrypt_command` always contains default path (don't checked)

Closes #30