### PR TITLE
Add ubuntu xenial in README under supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ the web server has been configured or even installed.
 # Supported platforms
 - Debian Jessie
 - Debian Stretch
+- Ubuntu Xenial
 
 On other platforms this role will try to install letsencrypt using pip, which is not officially supported and may break over upgrades at least.
 


### PR DESCRIPTION
Adds Ubuntu Xenial under supported platforms in Readme.

Supplement for https://github.com/thefinn93/ansible-letsencrypt/pull/64