### PR TITLE
Compare defined cert domains to existing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,19 +36,26 @@
       follow: yes
     become: yes
 
+  - name: Check is the cert domains changed
+    lineinfile:
+      path: "/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+      line: "{{ '%s = %s' % ( 'cert_domains', ( letsencrypt_cert_domains | to_yaml | from_yaml ) ) }}"
+      state: present
+    check_mode: yes
+    register: is_cert_domains
+    failed_when: no
+    changed_when: is_cert_domains.changed or ( is_cert_domains.rc is defined and is_cert_domains.rc != 0 )
+
   - name: Attempt to get the certificate using the webroot authenticator
     command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
     become: yes
-    args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
-    when: letsencrypt_authenticator == "webroot"
+    when: letsencrypt_authenticator == "webroot" and is_cert_domains.changed
     ignore_errors: True
 
   - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
     command: "{{ letsencrypt_command }} -a standalone auth {{ letsencrypt_standalone_command_args }}"
     become: yes
-    args:
-      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+    when: letsencrypt_authenticator != 'webroot' and is_cert_domains.changed
 
   - name: Fix the renewal file
     ini_file:
@@ -64,6 +71,7 @@
       uir: False
       hsts: False
       authenticator: '{{ letsencrypt_authenticator }}'
+      cert_domains: '{{ letsencrypt_cert_domains }}'
 
   - name: Fix the webroot map in the renewal file
     ini_file:


### PR DESCRIPTION
Compare defined certification hosts lists to current in renewal configuration file, and run the certbot if the list differs.
Closes #30 