### PR TITLE
support Ubuntu 20.04 Focal Fossa

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,9 +25,13 @@
     include: ubuntu-xenial.yml
     when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "xenial"
 
+  - name: install certbot (Ubuntu Focal)
+    include: ubuntu-focal.yml
+    when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "focal"
+
   - name: install certbot (using pip)
     include: install-with-pip.yml
-    when: ansible_distribution != "Debian" and (ansible_distribution != "Ubuntu" or ansible_distribution_release != "xenial")
+    when: ansible_distribution != "Debian" and (ansible_distribution != "Ubuntu" or ansible_distribution_release not in  ["xenial", "focal"])
 
   - name: Ensure webroot exists
     file:

--- a/tasks/ubuntu-focal.yml
+++ b/tasks/ubuntu-focal.yml
@@ -1,0 +1,14 @@
+---
+- name: update the apt cache
+  apt: update_cache=yes cache_valid_time=7200
+  become: yes
+
+- name: install certbot ubuntu
+  apt: pkg={{item}} state=latest
+  with_items:
+    - certbot
+  become: yes
+
+- name: change the path to letsencrypt
+  set_fact:
+    letsencrypt_path: "/usr/bin/letsencrypt"


### PR DESCRIPTION
I added features of ubuntu 20.04 support.

From Ubuntu 20.04 there are no "python-pip", "python-virtualenv" apt package.
Therefore I added sub-playbook "ubuntu-focal.yml" to use "certbot" apt package.